### PR TITLE
Add a setting to configure the display of exhibit items in the main menu

### DIFF
--- a/common/custom.php
+++ b/common/custom.php
@@ -34,6 +34,38 @@ function footer_logo($num = 1)
     }
 }
 
+/**
+ * Get an array of exhibits ordered by the config value
+ * 'Menu Ordering', which consists of comma-separated
+ * exhibit slugs. If the value is unset exhibits will be
+ * returned in primary key order.
+ *
+ * @return array of exhibits
+ */
+function get_exhibit_menu_items()
+{
+    $exhibits = get_db()->getTable('Exhibit')->findAll();
+    if (($menu_order = get_theme_option("Menu Ordering")) and !empty(trim($menu_order))) {
+        $slugs = array();
+        foreach ($exhibits as $exhibit) {
+            $slugs[$exhibit->slug] = $exhibit;
+        }
+
+        $ordered = array();
+        foreach (explode(',', $menu_order) as $slug) {
+            $key = trim($slug);
+            if (array_key_exists( $key, $slugs)) {
+                $ordered[] = $slugs[$key];
+            } else {
+                error_log("Invalid slug in exhibit menu config: '$key'");
+            }
+        }
+        return $ordered;
+    }
+
+    return $exhibits;
+}
+
 
 function link_to_next_item_show_custom($text = null, $props = array())
 {

--- a/common/header.php
+++ b/common/header.php
@@ -156,7 +156,7 @@ $searchQuery = array_key_exists('q', $_GET) ? $_GET['q'] : '';
         <div class="nav-bar-back-icon">chevron_left</div>
     </div>
     <ul>
-        <?php foreach (get_db()->getTable("Exhibit")->findAll() as $exhibit): ?>
+        <?php foreach (get_exhibit_menu_items() as $exhibit): ?>
             <li>
                 <a href="<?php echo record_url($exhibit); ?>"><?php echo $exhibit->title; ?></a>
                 <?php echo exhibit_builder_page_tree($exhibit); ?>

--- a/config.ini
+++ b/config.ini
@@ -25,6 +25,10 @@ footer_logo3.options.description = "Choose a footer logo file. This will replace
 footer_logo3.options.validators.count.validator = "Count"
 footer_logo3.options.validators.count.options.max = "1"
 
+; Menu Ordering
+menu_ordering.type = "text"
+menu_ordering.options.label = "Menu Ordering"
+menu_ordering.options.description = "Comma separated list of exhibit slugs ordered as displayed in the main menu."
 
 ; Header Background Image
 header_image.type = "file"
@@ -85,6 +89,9 @@ head_foot.elements[] = "header_image"
 head_foot.elements[] = "footer_text"
 head_foot.elements[] = "display_footer_copyright"
 head_foot.elements[] = "use_advanced_search"
+
+menu.options.legend = "Menu Config"
+menu.elements[] = "menu_ordering"
 
 homepage.options.legend = "Homepage"
 homepage.elements[] = "display_featured_item"


### PR DESCRIPTION
The setting is available in theme configuration and allows controlling exhibit order (and presence) in the main menu by listing their slugs as a comma-separated list.