### PR TITLE
Since the search summary is reused, rename its class to 'item-summary*'

### DIFF
--- a/common/pagination_control.php
+++ b/common/pagination_control.php
@@ -6,19 +6,19 @@ if ($this->pageCount > 1):
         <div class="search-results-pagination">
             <?php if (isset($this->previous)) { ?>
                 <!-- Previous page link -->
-                <div class="search-result-previous">
+                <div class="search-results-previous">
                     <?php $getParams['page'] = $previous; ?>
                     <a rel="prev" href="<?php echo html_escape($this->url(array(), null, $getParams)); ?>">
-                    <div class="search-result-image-previous">keyboard_arrow_left</div>
+                    <div class="search-results-image-previous">keyboard_arrow_left</div>
                     <?php echo __('Previous'); ?></a>
                 </div>
 			<?php } else { ?>
-				<div class="search-result-previous" style="opacity: 0.4"><div class="search-result-image-previous">keyboard_arrow_left</div>
+				<div class="search-results-previous" style="opacity: 0.4"><div class="search-results-image-previous">keyboard_arrow_left</div>
 					<?php echo __('Previous'); ?>
 				</div>
 			<?php } ?>
 
-            <div class="search-result-center">
+            <div class="search-results-center">
                 <form action="<?php echo html_escape($this->url()); ?>" method="get" accept-charset="utf-8">
                     <?php
                     $hiddenParams = array();
@@ -49,14 +49,14 @@ if ($this->pageCount > 1):
 
             <?php if (isset($this->next)) { ?>
                 <!-- Next page link -->
-                <div class="search-result-next">
+                <div class="search-results-next">
                     <?php $getParams['page'] = $next; ?>
                     <a rel="next" href="<?php echo html_escape($this->url(array(), null, $getParams)); ?>">
-                    <div class="search-result-image-next">keyboard_arrow_right</div>
+                    <div class="search-results-image-next">keyboard_arrow_right</div>
                     <?php echo __('Next'); ?></a>
                 </div>
 			<?php } else { ?>
-				<div class="search-result-next" style="opacity: 0.4"><div class="search-result-image-next">keyboard_arrow_right</div>
+				<div class="search-results-next" style="opacity: 0.4"><div class="search-results-image-next">keyboard_arrow_right</div>
 					<?php echo __('Next'); ?>
 				</div>
 			<?php } ?>

--- a/css/print.css
+++ b/css/print.css
@@ -347,57 +347,14 @@ height: 270px;
 }
 
 #search-container {
-
   width: 100%;
   margin: 0;
   padding: 0;
-  
 }
 
 .search-button-solr {
   right: 10px;
   top: 3px;
-}
-
-.search-result {
-  min-width: 0;
-  width: 100%;
-}
-
-.search-result-wrapper {
-  margin-left: 0;
-  width: 100%;
-}
-
-.search-result-title {
-  color: var(--colorTitle);
-  margin: 0 0 0 93px;
-}
-
-#home .search-result-title {
-  margin: 0;
-}
-
-.search-result-wrapper {
-  padding: 0;
-}
-
-.search-result p {
-  display: inline-block;
-  float: none;
-  margin: 12px 0 0 0;
-  width: 100%;
-}
-
-
-.search-result img {
-  height: 76px;
-  width: 76px;
-  margin: 0 17px 5px 0;
-}
-
-.search-result-image-blank {
-  display: none;
 }
 
 #search-container input[type=text] {
@@ -410,6 +367,47 @@ height: 270px;
   position: relative;
   margin: 0;
   width: 100%;
+}
+
+.item-summary {
+  min-width: 0;
+  width: 100%;
+}
+
+.item-summary-wrapper {
+  margin-left: 0;
+  width: 100%;
+}
+
+.item-summary-title {
+  color: var(--colorTitle);
+  margin: 0 0 0 93px;
+}
+
+#home .item-summary-title {
+  margin: 0;
+}
+
+.item-summary-wrapper {
+  padding: 0;
+}
+
+.item-summary p {
+  display: inline-block;
+  float: none;
+  margin: 12px 0 0 0;
+  width: 100%;
+}
+
+
+.item-summary img {
+  height: 76px;
+  width: 76px;
+  margin: 0 17px 5px 0;
+}
+
+.item-summary-image-blank {
+  display: none;
 }
 
 .header-search-background {

--- a/css/style-mobile.css
+++ b/css/style-mobile.css
@@ -98,11 +98,11 @@ h4 {
   list-style-type: none;
 }
 
-.search-result-exhibit-container {
+.editions-item {
   padding: 25px 0;
 }
 
-  .nav-bar {
+.nav-bar {
   display: none;
 }
 
@@ -423,30 +423,30 @@ height: 270px;
   top: 3px;
 }
 
-.search-result {
+.item-summary {
   min-width: 0;
   width: 100%;
 }
 
-.search-result-wrapper {
+.item-summary-wrapper {
   margin-left: 0;
   width: 100%;
 }
 
-.search-result-title {
+.item-summary-title {
   color: var(--colorTitle);
   margin: 0 0 0 93px;
 }
 
-#home .search-result-title {
+#home .item-summary-title {
   margin: 0;
 }
 
-.search-result-wrapper {
+.item-summary-wrapper {
   padding: 0;
 }
 
-.search-result p {
+.item-summary p {
   display: inline-block;
   float: none;
   margin: 12px 0 0 0;
@@ -454,13 +454,13 @@ height: 270px;
 }
 
 
-.search-result img {
+.item-summary img {
   height: 76px;
   width: 76px;
   margin: 0 17px 5px 0;
 }
 
-.search-result-image-blank {
+.item-summary-image-blank {
   display: none;
 }
 

--- a/css/style.css
+++ b/css/style.css
@@ -25,9 +25,9 @@ h1, h2, h3, h4, h5, h6,
 .nav-bar-search-category,
 .nav-bar-search-group,
 .related-chapters-title,
-.search-result-title,
-.search-result-previous,
-.search-result-next,
+.item-summary-title,
+.search-results-previous,
+.search-results-next,
 #site-title,
 #exhibit-home-site-title,
 label {
@@ -47,8 +47,8 @@ label {
 .search-button-solr,
 #search-container button,
 #header-search button,
-.search-result-image-next,
-.search-result-image-previous
+.search-results-image-next,
+.search-results-image-previous
   {
   font-family: 'Material Icons', serif;
   font-weight: normal;
@@ -1191,7 +1191,7 @@ header a:hover {
   width: 32px;
 }
 
-.search-result {
+.item-summary {
   border-bottom: 1px dashed var(--colorLineDashed);
   border-TOP: 1px dashed var(--colorLineDashed);
   color: var(--colorText);
@@ -1203,28 +1203,28 @@ header a:hover {
   width: calc(100% - 250px);
 }
 
-.search-result-exhibit-container {
+.editions-item {
   padding: 35px 0;
 }
 
-.search-result-empty {
+.search-results-empty {
   margin: 70px 0 0 0;
 }
 
-.search-result:hover.search-result-title {
+.item-summary:hover.item-summary-title {
   text-decoration: underline;
 }
 
-.search-result-wrapper:hover {
+.item-summary-wrapper:hover {
   text-decoration: none;
 }
 
-.search-result:hover.search-result img {
+.item-summary:hover.item-summary img {
   opacity: 0.8;
 }
 
 
-.search-result img {
+.item-summary img {
   background: #c2c2c2;
   float: left;
   height: 135px;
@@ -1233,7 +1233,7 @@ header a:hover {
   width: 135px;
 }
 
-.search-result-image-blank {
+.item-summary-image-blank {
   background: #c2c2c2;
   display: block;
   float: left;
@@ -1243,7 +1243,7 @@ header a:hover {
   width: 135px;
 }
 
-.search-result-title {
+.item-summary-title {
   color: var(--colorLink);
   font-size: 22px;
   font-weight: bold;
@@ -1253,7 +1253,7 @@ header a:hover {
   text-transform: none;
 }
 
-.search-result p {
+.item-summary p {
   font-size: 14px;
   margin: 12px 0 0 0;
 }
@@ -1262,7 +1262,7 @@ header a:hover {
   margin: 0 0 30px 0;
 }
 
-.search-result-wrapper {
+.item-summary-wrapper {
   margin-left: 135px;
   padding: 5px 0 0 30px;
 
@@ -1290,8 +1290,8 @@ header a:hover {
   width: 43px;
 }
 
-.search-result-image-next,
-.search-result-image-previous {
+.search-results-image-next,
+.search-results-image-previous {
   float: left;
   color: var(--colorLink);
   font-size: 20px;
@@ -1300,12 +1300,12 @@ header a:hover {
   font-weight: normal;
 }
 
-.search-result-image-next {
+.search-results-image-next {
   float: right;
 }
 
-.search-result-next,
-.search-result-previous {
+.search-results-next,
+.search-results-previous {
   color: var(--colorLink);
   float: left;
   font-size: 14px;
@@ -1315,12 +1315,12 @@ header a:hover {
   width: 33.33%;
 }
 
-.search-result-next { 
+.search-results-next {
   float: right;
   text-align: right;
 }
 
-.search-result-center { 
+.search-results-center {
   clear: both;
   display: inline-block;
   margin: 0 auto;
@@ -2074,7 +2074,7 @@ margin: 50px 0 0 -1px;
 }
 
 .element-text-language:hover {
-  color: var(--colorLinkHover:);
+  color: var(--colorLinkHover);
 }
 
 .element-text-page {
@@ -2546,7 +2546,7 @@ footer .navigation {
   width: calc(100% - 298px);
 }
 
-#exhibit-blocks > .exhibit-block .search-result > .search-result-wrapper > .record-metadata > p {
+#exhibit-blocks > .exhibit-block .item-summary > .item-summary-wrapper > .record-metadata > p {
   font-size: 14px;
   margin: 12px 0 0 0;
   
@@ -2615,7 +2615,7 @@ footer .navigation {
   margin: 25px 0 0 0;
 }
 
-#home .search-result {
+#home .item-summary {
   width: 100%;
 }
 

--- a/items/single-recent.php
+++ b/items/single-recent.php
@@ -1,4 +1,4 @@
-<div id="recent-items" class="search-result">
+<div id="recent-items" class="item-summary">
     <?php
     $title = metadata($item, 'display_title', array('snippet' => 100));
     ?>
@@ -8,12 +8,12 @@
             array('class' => 'image'), 'show', $item
         );
     } else {
-		echo '<div class="search-result-image-blank"></div>';
+		echo '<div class="item-summary-image-blank"></div>';
 	}
     ?>
-    <div class="search-result-wrapper">
+    <div class="item-summary-wrapper">
 		<?php if ($title): ?>
-			<div class="search-result-title"><?php echo $title; ?></div>
+			<div class="item-summary-title"><?php echo $title; ?></div>
 			<p>EHRI-BF-19380509b</p>
 			<p>1938-08-05&nbsp;&nbsp;|&nbsp;&nbsp;Schmolka, Marie&nbsp;&nbsp;|&nbsp;&nbsp;Amsterdam</p>
 			<p>Der sich in England befindender Weissmandl legt einen Bericht über die Verfolgung und Ausweisung der Juden aus Burgenland vor, sowie über die Illegale Hilfeleistung des orthodoxen Hilfskommittees. Er beantragt Unterstützung und persönliches Treffen mit dem Committee.</p>

--- a/search/index.php
+++ b/search/index.php
@@ -37,9 +37,9 @@ $( document ).ready(function(){
 
 	if ($total_results <= 50) {
 		echo "<div class=\"search-results-pagination\">
-				<div class=\"search-result-previous\"><div class=\"search-result-image-previous\">keyboard_arrow_left</div>Previous</div>
-				<div class=\"search-result-center\"><input class=\"search-result-center-input\" value=\"1\">of 1</div>
-				<div class=\"search-result-next\"><div class=\"search-result-image-next\">keyboard_arrow_right</div>Next</div>
+				<div class=\"search-results-previous\"><div class=\"search-results-image-previous\">keyboard_arrow_left</div>Previous</div>
+				<div class=\"search-results-center\"><input class=\"search-results-center-input\" value=\"1\">of 1</div>
+				<div class=\"search-results-next\"><div class=\"search-results-image-next\">keyboard_arrow_right</div>Next</div>
 			  </div>";}
 ?>
 <?php echo pagination_links(); ?>
@@ -50,8 +50,8 @@ $( document ).ready(function(){
         <?php $recordType = $searchText['record_type']; ?>
         <?php set_current_record($recordType, $record); ?>
         
-        <a clas="search-result-link" href="<?php echo record_url($record, 'show'); ?>">
-			<div class="search-result">
+        <a class="item-summary-link" href="<?php echo record_url($record, 'show'); ?>">
+			<div class="item-summary">
 				<?php
 				$date = metadata($record, array('Dublin Core', 'Date'));
 				$place = metadata($record, array('Dublin Core', 'Publisher'));
@@ -59,10 +59,10 @@ $( document ).ready(function(){
 				<?php if ($recordImage = record_image($recordType)) {  ?>
                     <?php echo $recordImage ?>                    
                 <?php } else { ?>
-					<div class="search-result-image-blank"></div>
+					<div class="item-summary-image-blank"></div>
 				<?php } ?>
-				<div class="search-result-wrapper">
-					<div class="search-result-title"><?php echo $searchText['title'] ? $searchText['title'] : '[Unknown]'; ?></div>
+				<div class="item-summary-wrapper">
+					<div class="item-summary-title"><?php echo $searchText['title'] ? $searchText['title'] : '[Unknown]'; ?></div>
 					<?php if (isset($date)){ $addition = $date; } ?> 
 					<?php if (isset($place)){ $addition = $date . " | " . $place; }?>           
 					<?php if($addition){echo "<p>$addition</p>";} ?> 
@@ -75,14 +75,14 @@ $( document ).ready(function(){
 
 <?php if ($total_results >= 2) {
 	echo "<div class=\"search-results-pagination\">
-			<div class=\"search-result-previous\"><div class=\"search-result-image-previous\">keyboard_arrow_left</div>Previous</div>
-			<div class=\"search-result-center\"><input class=\"search-result-center-input\" value=\"1\">of 1</div>
-			<div class=\"search-result-next\"><div class=\"search-result-image-next\">keyboard_arrow_right</div>Next</div>
+			<div class=\"search-results-previous\"><div class=\"search-results-image-previous\">keyboard_arrow_left</div>Previous</div>
+			<div class=\"search-results-center\"><input class=\"search-results-center-input\" value=\"1\">of 1</div>
+			<div class=\"search-results-next\"><div class=\"search-results-image-next\">keyboard_arrow_right</div>Next</div>
 		  </div>";}
 ?>
 <?php else: ?>
 
-<div id="no-results" class="search-result-empty">
+<div id="no-results" class="search-results-empty">
     <h1><br>No results for “TEXT”.</h1>
 </div>
 

--- a/solr-search/results/index.php
+++ b/solr-search/results/index.php
@@ -36,7 +36,7 @@ $searchQuery = array_key_exists('q', $_GET) ? $_GET['q'] : '';
 
                 <?php set_current_record("item", $record); ?>
 
-                <div class="search-result">
+                <div class="item-summary">
                     <?php
                         $date = metadata($record, array('Dublin Core', 'Date'));
                         $place = metadata($record, array('Dublin Core', 'Publisher'));
@@ -45,12 +45,12 @@ $searchQuery = array_key_exists('q', $_GET) ? $_GET['q'] : '';
                         <?php if ($recordImage = record_image("item")):  ?>
                             <?php echo $recordImage ?>
                         <?php else: ?>
-                            <div class="search-result-image-blank"></div>
+                            <div class="item-summary-image-blank"></div>
                         <?php endif; ?>
                     </a>
-                    <div class="search-result-wrapper">
-                        <a class="search-result-link" href="<?php echo $url; ?>">
-                            <div class="search-result-title"><?php echo metadata($record, 'display_title'); ?></div>
+                    <div class="item-summary-wrapper">
+                        <a class="item-summary-link" href="<?php echo $url; ?>">
+                            <div class="item-summary-title"><?php echo metadata($record, 'display_title'); ?></div>
                         </a>
                         <?php if (isset($date)){ $addition = $date; } ?>
                         <?php if (isset($place)){ $addition = $date . " | " . $place; }?>
@@ -66,7 +66,7 @@ $searchQuery = array_key_exists('q', $_GET) ? $_GET['q'] : '';
 	<?php echo pagination_links(); ?>
 
 <?php else: ?>
-	<div id="no-results" class="search-result-empty"><h1>
+	<div id="no-results" class="search-results-empty"><h1>
 	<?php if (strlen($searchQuery)>0) { ?>
 		<?php echo __("No results for \"%s\"", $searchQuery); ?>.
 	<?php } else { ?>


### PR DESCRIPTION
Also change some css classes that pertain to the whole search and not individual items to have the prefix search-results plural instead of singular.

Also rename 'search-item-exhibit-container' to 'editions-item'